### PR TITLE
Added file with functions to autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
             "/testcase/",
             "/tests/",
             "simple_html_dom.php"
+        ],
+        "files": [
+            "simple_html_dom.php"
         ]
     },
     "require": {


### PR DESCRIPTION
Without auto-loading, function calls like str_get_html() cannot be used by default.